### PR TITLE
Added code coverage measurement

### DIFF
--- a/.github/actions/build-native-binary/action.yaml
+++ b/.github/actions/build-native-binary/action.yaml
@@ -43,12 +43,12 @@ runs:
       sudo apt-get -y update
       sudo apt-get -y upgrade
       sudo apt-get -y install autoconf binutils cmake file \
-      gcc g++ git libtool make \
-      build-essential libcurl4-openssl-dev \
-      binutils-aarch64-linux-gnu gcc-9-aarch64-linux-gnu g++-9-aarch64-linux-gnu \
-      python3 python3-pip python3-setuptools python3-wheel ninja-build python3-pip \
-      libselinux1-dev libmount-dev libmount1 libblkid-dev
-      pip3 install meson
+        gcc g++ git libtool make gcovr \
+        build-essential libcurl4-openssl-dev \
+        binutils-aarch64-linux-gnu gcc-9-aarch64-linux-gnu g++-9-aarch64-linux-gnu \
+        python3 python3-pip python3-setuptools python3-wheel ninja-build python3-pip \
+        libselinux1-dev libmount-dev libmount1 libblkid-dev
+        pip3 install meson
     shell: bash
 
   - name: Build for ${{ inputs.arch }}
@@ -60,9 +60,27 @@ runs:
       cmake \
         -DCMAKE_INSTALL_PREFIX=../dist_${{ inputs.arch }} \
         -DCMAKE_TOOLCHAIN_FILE=../cmake/linux/${{ matrix.arch }}/toolchain.cmake \
-        -DOPENSSL_ROOT_DIR=../build_${{ matrix.arch }} \
-        -DOPENSSL_CRYPTO_LIBRARY=../build_${{ matrix.arch }}/lib/libcrypto.so \
-        -DSUA_BUILD_NUMBER=${{ inputs.run_number }} ..
+        -DOPENSSL_ROOT_DIR=. \
+        -DOPENSSL_CRYPTO_LIBRARY=lib/libcrypto.so \
+        -DSUA_BUILD_NUMBER=${{ inputs.run_number }} \
+        -DSUA_BUILD_TESTS=NO \
+        ..
+      make
+      make install
+    shell: bash
+
+  - name: Build for ${{ inputs.arch }} (with code-coverage enabled)
+    if: ${{ inputs.arch=='amd64' }}
+    run: |
+      cd build_${{ inputs.arch }}
+      cmake \
+        -DCMAKE_INSTALL_PREFIX=../dist_${{ inputs.arch }}_testing \
+        -DCMAKE_TOOLCHAIN_FILE=../cmake/linux/${{ matrix.arch }}/toolchain.cmake \
+        -DOPENSSL_ROOT_DIR=. \
+        -DOPENSSL_CRYPTO_LIBRARY=lib/libcrypto.so \
+        -DSUA_BUILD_NUMBER=${{ inputs.run_number }} \
+        -DSUA_BUILD_TESTS=YES \
+        ..
       make
       make install
     shell: bash
@@ -70,8 +88,11 @@ runs:
   - name: Run unit tests
     if: ${{ inputs.arch=='amd64' }}
     run: |
-      cd dist_${{ inputs.arch }}/utest
-      ./TestSDVSelfUpdateAgent
+      cd dist_${{ inputs.arch }}_testing/utest
+      ./TestSelfUpdateAgent
+      mkdir report
+      gcovr --root ../.. --html --html-details --output report/coverage.html -e ../../3rdparty -e ../../utest -e ../../src/main.cpp
+      tar -czvf ../../code-coverage.tar.gz report
     shell: bash
 
   - name: Compress artifacts

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -90,11 +90,16 @@ jobs:
           arch: ${{ matrix.arch }}
           run_number: ${{ github.run_number }}
 
-      - name: Upload ${{ matrix.arch }} artifact to workspace
+      - name: Upload ${{ matrix.arch }} artifacts to workspace
         uses: actions/upload-artifact@v3
         with:
-          name: self-update-agent-${{ matrix.arch }}-build-${{ github.run_number }}.tar.gz
           path: self-update-agent-${{ matrix.arch }}-build-${{ github.run_number }}.tar.gz
+
+      - name: Upload code coverage results to workspace
+        if: ${{ matrix.arch == 'amd64' }}
+        uses: actions/upload-artifact@v3
+        with:
+          path: code-coverage.tar.gz
 
   upload-native-binary:
     runs-on: ubuntu-latest
@@ -115,5 +120,7 @@ jobs:
           prerelease: true
           automatic_release_tag: build_${{ github.run_number }}
           title: "Build ${{ github.run_number }}"
-          files: "**/self-update-agent-*-build-${{ github.run_number }}.tar.gz"
-
+          files: |
+            ./artifact/code-coverage.tar.gz
+            ./artifact/self-update-agent-amd64-build-${{ github.run_number }}.tar.gz
+            ./artifact/self-update-agent-arm64-build-${{ github.run_number }}.tar.gz

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -22,6 +22,6 @@ set(BUILD_SHARED_LIBS ON)
 set(BUILD_CURL_EXE    OFF)
 add_subdirectory(curl)
 
-if(SDV_SUA_BUILD_TESTS)
+if(SUA_BUILD_TESTS)
   add_subdirectory(googletest)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,15 @@ set(CMAKE_SKIP_BUILD_RPATH TRUE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 set(CMAKE_INSTALL_RPATH ../lib)
 
-set(SDV_SUA_BUILD_TESTS TRUE)
+option(SUA_BUILD_TESTS "Build unit tests with code-coverage report enabled" OFF)
 
 include(cmake/dependencies.cmake)
 
 add_subdirectory(3rdparty)
 add_subdirectory(src)
 
-if(SDV_SUA_BUILD_TESTS)
+if(SUA_BUILD_TESTS)
     add_subdirectory(utest)
 endif()
+
+unset(SUA_BUILD_TESTS CACHE)

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -34,8 +34,8 @@ RUN cd /work \
     && cmake \
         -DCMAKE_INSTALL_PREFIX=../dist_amd64 \
         -DCMAKE_TOOLCHAIN_FILE=../cmake/linux/amd64/toolchain.cmake \
-        -DOPENSSL_ROOT_DIR=../build_amd64 \
-        -DOPENSSL_CRYPTO_LIBRARY=../build_amd64/lib/libcrypto.so \
+        -DOPENSSL_ROOT_DIR=. \
+        -DOPENSSL_CRYPTO_LIBRARY=lib/libcrypto.so \
         -DCMAKE_BUILD_TYPE="Release" \
         -DSUA_BUILD_NUMBER=$GITHUB_RUN_NUMBER \
         -DSUA_COMMIT_HASH=$GITHUB_COMMIT_HASH \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -34,8 +34,8 @@ RUN cd /work \
     && cmake \
         -DCMAKE_INSTALL_PREFIX=../dist_arm64 \
         -DCMAKE_TOOLCHAIN_FILE=../cmake/linux/arm64/toolchain.cmake \
-        -DOPENSSL_ROOT_DIR=../build_arm64 \
-        -DOPENSSL_CRYPTO_LIBRARY=../build_arm64/lib/libcrypto.so \
+        -DOPENSSL_ROOT_DIR=. \
+        -DOPENSSL_CRYPTO_LIBRARY=lib/libcrypto.so \
         -DCMAKE_BUILD_TYPE="Release" \
         -DSUA_BUILD_NUMBER=$GITHUB_RUN_NUMBER \
         -DSUA_COMMIT_HASH=$GITHUB_COMMIT_HASH \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,14 @@ if(NOT DEFINED SUA_BUILD_NUMBER)
     set(SUA_BUILD_NUMBER "local")
 endif()
 
+if(SUA_BUILD_TESTS)
+    add_compile_options(
+        -fprofile-arcs
+        -ftest-coverage
+        -fPIC
+    )
+endif()
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/version.h @ONLY)
 
 include_directories(
@@ -56,6 +64,10 @@ target_link_libraries(${PROJECT_NAME}
     sua
 )
 
+if(SUA_BUILD_TESTS)
+    target_link_libraries(sua gcov)
+endif()
+
 install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 install(TARGETS sua LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 
@@ -65,4 +77,3 @@ install(
         ${CMAKE_BINARY_DIR}/lib/libcrypto.so.3
     DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
 )
-

--- a/utest/CMakeLists.txt
+++ b/utest/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(TestSDVSelfUpdateAgent
+add_executable(TestSelfUpdateAgent
     TestDispatcher.cpp
     TestFSM.cpp
     TestMqttMessagingProtocolYAML.cpp
@@ -12,7 +12,7 @@ include_directories(
 )
 
 target_link_libraries(
-    TestSDVSelfUpdateAgent
+    TestSelfUpdateAgent
     sua
     curl_lib
     paho-mqttpp3
@@ -31,4 +31,4 @@ target_link_libraries(
     gmock
 )
 
-install(TARGETS TestSDVSelfUpdateAgent RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/utest)
+install(TARGETS TestSelfUpdateAgent RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/utest)


### PR DESCRIPTION
Workflows and cmake build scripts are extended to measure code coverage using unit tests. Enabled only for amd64 arch.